### PR TITLE
depthimage_to_laserscan for scan line offset

### DIFF
--- a/rosinstalls/indigo/gopher_navigation.rosinstall
+++ b/rosinstalls/indigo/gopher_navigation.rosinstall
@@ -6,3 +6,4 @@
 - git: {local-name: depth_calibration, version: indigo, uri: 'https://github.com/yujinrobot/depth_calibration.git'}
 - git: {local-name: yujin_ocs, version: indigo-devel, uri: 'https://github.com/yujinrobot/yujin_ocs.git'}
 - git: {local-name: yocs_msgs, version: indigo-devel, uri: 'https://github.com/yujinrobot/yocs_msgs.git'}
+- git: {local-name: depthimage_to_laserscan, version: indigo-devel, uri: 'https://github.com/AlexReimann/depthimage_to_laserscan.git'}


### PR DESCRIPTION
For the long range scan line. The normal version only supports a scan line right in the center.