### PR TITLE
Getting rid of flask-ext-catkin

### DIFF
--- a/rosinstalls/indigo/gopher_rocon.rosinstall
+++ b/rosinstalls/indigo/gopher_rocon.rosinstall
@@ -30,7 +30,6 @@
 # Rostful and Celeros
 {'git': {'local-name': 'rostful', 'version': 'indigo-devel', 'uri': 'https://github.com/asmodehn/rostful.git'}},
 {'git': {'local-name': 'celeros', 'version': 'indigo-devel', 'uri': 'https://github.com/asmodehn/celeros.git'}},
-{'git': {'local-name': 'flask-ext-catkin', 'version': 'indigo-devel', 'uri': 'https://github.com/asmodehn/flask-ext-catkin.git'}},
 {'git': {'local-name': 'rostful-node', 'version': 'indigo-devel', 'uri': 'https://github.com/asmodehn/rostful-node.git'}},
 
 # Door and Elevator Integration


### PR DESCRIPTION
not needed anymore. dependencies are added directly as submodules in celeros, rostful, flask_task_planner.