### PR TITLE
Renaming rostful-node repo

### DIFF
--- a/rosinstalls/indigo/gopher_rocon.rosinstall
+++ b/rosinstalls/indigo/gopher_rocon.rosinstall
@@ -30,7 +30,7 @@
 # Rostful and Celeros
 {'git': {'local-name': 'rostful', 'version': 'indigo-devel', 'uri': 'https://github.com/asmodehn/rostful.git'}},
 {'git': {'local-name': 'celeros', 'version': 'indigo-devel', 'uri': 'https://github.com/asmodehn/celeros.git'}},
-{'git': {'local-name': 'rostful-node', 'version': 'indigo-devel', 'uri': 'https://github.com/asmodehn/rostful-node.git'}},
+{'git': {'local-name': 'pyros', 'version': 'indigo-devel', 'uri': 'https://github.com/asmodehn/pyros.git'}},
 
 # Door and Elevator Integration
 {'git': {'local-name': 'door_interactions', 'version': 'indigo', 'uri': 'https://bitbucket.org/yujinrobot/door_interactions.git'}},


### PR DESCRIPTION
Because that package is not really related to rostful anymore.