### PR TITLE
now using gopher specific branch for pyros and co.

### DIFF
--- a/rosinstalls/indigo/gopher_bootstrap-devel.rosinstall
+++ b/rosinstalls/indigo/gopher_bootstrap-devel.rosinstall
@@ -15,9 +15,9 @@
 - git: { local-name: 'py_trees_suite',                version: 'indigo-devel', uri: 'https://bitbucket.org/yujinrobot/py_trees_suite.git'}
 
 # Rostful and Celeros
-- git: { local-name: 'rostful',                       version: 'indigo-devel', uri: 'https://github.com/asmodehn/rostful.git'}
-- git: { local-name: 'celeros',                       version: 'indigo-devel', uri: 'https://github.com/asmodehn/celeros.git'}
-- git: { local-name: 'pyros',                         version: 'indigo-devel', uri: 'https://github.com/asmodehn/pyros.git'}
+- git: { local-name: 'rostful',                       version: 'gopher-devel', uri: 'https://github.com/asmodehn/rostful.git'}
+- git: { local-name: 'celeros',                       version: 'gopher-devel', uri: 'https://github.com/asmodehn/celeros.git'}
+- git: { local-name: 'pyros',                         version: 'gopher-devel', uri: 'https://github.com/asmodehn/pyros.git'}
 
 # Environment Integrations
 - git: { local-name: 'elevator_interactions',         version: 'indigo-devel', uri: 'https://bitbucket.org/yujinrobot/elevator_interactions.git'}


### PR DESCRIPTION
This is to allow separate development, without impacting what gopher uses.