### PR TITLE
Fix rsynch binaries target path for groot_arm_binaries

### DIFF
--- a/Changelog
+++ b/Changelog
@@ -1,3 +1,5 @@
+0.4.54
+ - groot_arm_binaries : fix external server rsynch path
 0.4.53
  - yujin_tools : dropped dependencies to packages from ROS repositories
 0.4.52

--- a/scripts/groot_arm_binaries
+++ b/scripts/groot_arm_binaries
@@ -63,7 +63,7 @@ export local_dir=/opt/yujin/arm  # this copies the indigo folder
 
 if [ ! -z "$EXTERNAL" ]; then
   export remote_url=files@files.yujinrobot.com
-  export remote_dir=${remote_url}:rsync_repositories/yujin/arm
+  export remote_dir=${remote_url}:/data/file_server/rsync_repositories/yujin/arm
 else
   export remote_url=files@files.yujin.com
   export remote_dir=${remote_url}:shared/installspaces/yujin/arm

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ sys.path.insert(0, 'src')
 # to get that here *and* there and we don't exactly use
 # the module version anywhere, so keep it simple...
 # just here for now.
-__version__ = '0.4.53'
+__version__ = '0.4.54'
 
 setup(name='yujin_tools',
       version= __version__,


### PR DESCRIPTION
External server doesn't have rsync_repositories/yujin/arm directory . 
Change it to /data/file_server/rsync_repositories/yujin.