### PR TITLE
adds elevator_operator package docs to stable list

### DIFF
--- a/docs/groot-stable.yaml
+++ b/docs/groot-stable.yaml
@@ -14,6 +14,7 @@ messages:
  - py_trees_msgs
  - yocs_msgs
 bootstrap:
+ - elevator_operator
  - gopher_networking
  - gopher_version
 desktop:


### PR DESCRIPTION
It has been released with Catchy.

Probably more should be added (e.g. most of current devel).