### PR TITLE
adds elevator_operator package docs to stable-partners list

### DIFF
--- a/docs/groot-stable-partners.yaml
+++ b/docs/groot-stable-partners.yaml
@@ -14,6 +14,7 @@ messages:
  - py_trees_msgs
  - yocs_msgs
 bootstrap:
+ - elevator_operator
  - gopher_networking
  - gopher_version
 desktop:


### PR DESCRIPTION
It has been released with Catchy.

Probably more should be added.