### PR TITLE
[bootstrap-devel] pyros_schemas: asmohdem/master -> naveedhd/temp_set…

### DIFF
--- a/rosinstalls/indigo/gopher_bootstrap-devel.rosinstall
+++ b/rosinstalls/indigo/gopher_bootstrap-devel.rosinstall
@@ -34,7 +34,7 @@
 - git: { local-name: 'rostful',               version: 'gopher-devel', uri: 'https://github.com/asmodehn/rostful.git'}
 - git: { local-name: 'pyros',                 version: 'gopher-devel', uri: 'https://github.com/asmodehn/pyros.git'}
 # Only in case of testing before package release
-- git: { local-name: 'pyros_schemas',         version: 'master', uri: 'https://github.com/asmodehn/pyros-schemas.git'}
+- git: { local-name: 'pyros_schemas',         version: 'temp_setup_install', uri: 'https://github.com/naveedhd/pyros-schemas.git'}
 - git: { local-name: 'pyros_msgs',            version: 'master', uri: 'https://github.com/asmodehn/pyros-msgs.git'}
 # - git: { local-name: 'pyros_config',        version: 'release/indigo/pyros_config', uri: 'https://github.com/asmodehn/pyros-config-rosrelease.git'}
 


### PR DESCRIPTION
…up_install

This is until the next release of `pyros_schemas`. This is required because one of our package running from binaries depends on it.