### PR TITLE
detecting system distro for deb upload.

### DIFF
--- a/scripts/yujin_upload_deb
+++ b/scripts/yujin_upload_deb
@@ -21,8 +21,8 @@ PACKAGES_URI="packages.yujinrobot.com"
 PACKAGES_URL="http://${PACKAGES_URI}"
 PACKAGES_SSH="files@${PACKAGES_URI}"
 PACKAGES_SCRIPTS_DIR="/data/repos/scripts"
-UBUNTU_ARCH=amd64
-UBUNTU_VERSION_string="trusty"
+UBUNTU_ARCH="$(dpkg --print-architecture)"   # get current machine architecture
+UBUNTU_VERSION_string="$(lsb_release -cs)"  # get current release codename
 COMPONENT_NAME=""
 
 ###########################


### PR DESCRIPTION
This uses the running system to determine UBUNTU_VERSION and UBUNTU_ARCH.
Not sure if it is a good idea (especially the arch ? how cross-compiling arm deb work ?), but very likely an improvement on existing code, since we need to start supporting `xenial` packages at least.