### PR TITLE
removing flask_task_planner from concert rosinstall

### DIFF
--- a/rosinstalls/indigo/gopher_concert-devel.rosinstall
+++ b/rosinstalls/indigo/gopher_concert-devel.rosinstall
@@ -10,7 +10,7 @@
 
 # Gopher specific requirements
 - git: { local-name: 'gopher_concert',         version: 'devel', uri: 'https://bitbucket.org/yujinrobot/gopher_concert.git'}
-- git: { local-name: 'flask_task_planner',     version: 'devel', uri: 'https://bitbucket.org/yujinrobot/flask-task-planner.git'}
+# - git: { local-name: 'flask_task_planner',     version: 'devel', uri: 'https://bitbucket.org/yujinrobot/flask-task-planner.git'}
 
 # REST API specification for the gopher concert
 - git: { local-name: 'gopher_concert_restful', version: 'devel', uri: 'https://bitbucket.org/yujinrobot/gopher_concert_restful'}


### PR DESCRIPTION
We can do this after https://bitbucket.org/yujinrobot/gopher_concert/pull-requests/36/removing-celeros-based-scheduler-from/diff has been merged