### PR TITLE
removing flask_task_planner

### DIFF
--- a/rosinstalls/indigo/gopher_concert-devel.rosinstall
+++ b/rosinstalls/indigo/gopher_concert-devel.rosinstall
@@ -10,7 +10,8 @@
 
 # Gopher specific requirements
 - git: { local-name: 'gopher_concert',         version: 'devel', uri: 'https://bitbucket.org/yujinrobot/gopher_concert.git'}
-- git: { local-name: 'flask_task_planner',     version: 'devel', uri: 'https://bitbucket.org/yujinrobot/flask-task-planner.git'}
+# Removing : Not used any more
+# - git: { local-name: 'flask_task_planner',     version: 'devel', uri: 'https://bitbucket.org/yujinrobot/flask-task-planner.git'}
 
 # REST API specification for the gopher concert
 - git: { local-name: 'gopher_concert_restful', version: 'devel', uri: 'https://bitbucket.org/yujinrobot/gopher_concert_restful'}


### PR DESCRIPTION
not used anymore (replaced with dockerized nodejs web service)