### PR TITLE
[rosinstalls] removed concert multimaster repo

### DIFF
--- a/rosinstalls/indigo/gopher_bootstrap-devel.rosinstall
+++ b/rosinstalls/indigo/gopher_bootstrap-devel.rosinstall
@@ -45,9 +45,6 @@
 # - git: { local-name: 'pyros',                 version: 'release/indigo/pyros', uri: 'https://github.com/asmodehn/pyros-rosrelease.git'}
 # - git: { local-name: 'pyros_config',        version: 'release/indigo/pyros_config', uri: 'https://github.com/asmodehn/pyros-config-rosrelease.git'}
 
-# Ros 2 Concert communications (hopefully deprecating sometime)
-- git: { local-name: 'rocon_multimaster',     version: 'devel',        uri: 'https://github.com/robotics-in-concert/rocon_multimaster.git'}
-
 # Deployment
 - git: { local-name: 'yujin_ansible',     version: 'devel',        uri: 'https://bitbucket.org/yujinrobot/yujin_ansible'}
 


### PR DESCRIPTION
We don't need rocon_multimaster repo, we are not depending on it since we dropped Concert communication via ROS protocols...