### PR TITLE
Add two continental branch for lidar fusion

### DIFF
--- a/rosinstalls/indigo/gopher-continental.rosinstall
+++ b/rosinstalls/indigo/gopher-continental.rosinstall
@@ -7,7 +7,7 @@
 
 # Mostly for gopher_robot which contains all launchers and parameterisations for bringing up a gopher robot.
 # Also includes a few other essentials such as the remote gopher utilities.
-- git: { local-name: 'gopher',             version: 'devel',         uri: 'https://bitbucket.org/yujinrobot/gopher.git'}
+- git: { local-name: 'gopher',             version: 'continental',         uri: 'https://bitbucket.org/yujinrobot/gopher.git'}
 
 # Calibration software (mostly for the 2d/3d sensors)
 - git: { local-name: 'gopher_calibration', version: 'devel',         uri: 'https://bitbucket.org/yujinrobot/gopher_calibration.git'}

--- a/rosinstalls/indigo/gopher_dslam-continental.rosinstall
+++ b/rosinstalls/indigo/gopher_dslam-continental.rosinstall
@@ -9,7 +9,7 @@
 # The core dslam library (no gui needed)
 - git: {local-name: dslam,                  version: devel, uri: 'https://bitbucket.org/yujinrobot/dslam.git'}
 # Ecto pipeline, map utilities and viewers for dslam
-- git: {local-name: dslam_desktop,          version: devel, uri: 'https://bitbucket.org/yujinrobot/dslam_desktop.git'}
+- git: {local-name: dslam_desktop,          version: continental, uri: 'https://bitbucket.org/yujinrobot/dslam_desktop.git'}
 # Map version information only
 - git: {local-name: dslam_map_version,      version: devel, uri: 'https://bitbucket.org/yujinrobot/dslam_map_version.git'}
 # Supporting qglv widgets and algorithms to create dslam viewers
@@ -17,7 +17,7 @@
 # Localisation framework, includes initialisation methods with AR markers
 - git: {local-name: elf,                    version: devel, uri: 'https://bitbucket.org/yujinrobot/elf.git'}
 # Yujin libraries
-- git: { local-name: 'shield',         version: 'devel',         uri: 'https://bitbucket.org/yujinrobot/shield.git'}
+- git: { local-name: 'shield',         version: 'continental',         uri: 'https://bitbucket.org/yujinrobot/shield.git'}
 
 # Open source releases that are often changing
 # support library for mixing ros and sophus


### PR DESCRIPTION
Make continental branch with gopher in gopher workspace, shield and dslam_desktop in dslam workspace.
Since lidar fusion will be tested continental first.