### PR TITLE
To fix navi_ws build error

### DIFF
--- a/rosinstalls/indigo/gopher_navigation-continental.rosinstall
+++ b/rosinstalls/indigo/gopher_navigation-continental.rosinstall
@@ -21,7 +21,7 @@
 # Any important (especially IP sensitive) navigation code in here, especially local and global planning packages.
 - git: {local-name: 'gopher_navigation',       version: 'devel', uri: 'https://bitbucket.org/yujinrobot/gopher_navigation.git'}
 # Any not so important navigation packages - docking, elevators, simple motions, etc.
-- git: {local-name: 'gopher_motion_control',   version: 'continental', uri: 'https://bitbucket.org/yujinrobot/gopher_motion_control.git'}
+- git: {local-name: 'gopher_motion_control',   version: 'devel', uri: 'https://bitbucket.org/yujinrobot/gopher_motion_control.git'}
 # Forks of the open source ROS navistack
 - git: {local-name: 'navigation',              version: 'devel', uri: 'https://github.com/yujinrobot/navigation.git'}
 - git: {local-name: 'navigation_layers',       version: 'devel', uri: 'https://github.com/yujinrobot/navigation_layers.git'}


### PR DESCRIPTION
[previous]
- git: {local-name: 'gopher_motion_control',   version: 'continental', uri: 'https://bitbucket.org/yujinrobot/gopher_motion_control.git'}


[after change]
- git: {local-name: 'gopher_motion_control',   version: 'devel', uri: 'https://bitbucket.org/yujinrobot/gopher_motion_control.git'}